### PR TITLE
Remove `CustomStringConvertible` constraint on `typeMismatch` function

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,3 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
-xctool -project Argo.xcodeproj -scheme Argo-Mac -sdk macosx clean test
+set -o pipefail
+
+xcrun xcodebuild \
+  -workspace Argo.xcworkspace \
+  -scheme Argo-Mac \
+  test \
+  | xcpretty --color
+

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,11 @@
 machine:
-  environment:
-    XCODE_SCHEME: Argo-Mac
   xcode:
-    version: 6.3.1
+    version: "7.1"
+
+dependencies:
+  override:
+    - git submodule update --init --recursive
+
+test:
+  override:
+    - bin/test

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,9 @@
 machine:
   xcode:
     version: "7.1"
+  environment:
+    XCODE_SCHEME: nonce
+    XCODE_WORKSPACE: nonce.xcworkspace
 
 dependencies:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: "7.1"
+    version: "7.0"
   environment:
     XCODE_SCHEME: nonce
     XCODE_WORKSPACE: nonce.xcworkspace


### PR DESCRIPTION
According to Apple's [documentation](https://developer.apple.com/library/prerelease/ios/documentation/Swift/Reference/Swift_CustomStringConvertible_Protocol/index.html) of `CustomStringConvertible`: 
> `String(instance)` will work for an `instance` of _any_ type, returning its `description` if the `instance` happens to be `CustomStringConvertible`. Using `CustomStringConvertible` as a generic constraint, or accessing a conforming type's `description` directly, is therefore discouraged.

Hence we can unify the `typeMismatch` function so that it accepts _any_ types.